### PR TITLE
Silently cancel most damage types & preserve original health

### DIFF
--- a/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
@@ -145,9 +145,11 @@ public class AdminManager implements Listener
         Admin admin = getOnlineAdmin(player);
         if (admin.getAdminState() == AdminState.FREEROAM) return;
 
-        Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(AdminToolbox.getInstance(), () -> {
-            player.setHealth(20);
-        }, 1L);
+        double oldHealth = player.getHealth();
+
+        player.getScheduler().runDelayed(AdminToolbox.getInstance(), (task) -> {
+            player.setHealth(oldHealth);
+        }, null, 1L);
     }
 
     @EventHandler

--- a/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
@@ -138,11 +138,9 @@ public class AdminManager implements Listener
     }*/
 
     @EventHandler
-    void onAdminHurt(EntityDamageEvent event)
-    {
+    void onAdminHurt(EntityDamageEvent event) {
         // admins not in free roam can't be hurt
-        if (event.getEntity() instanceof Player player)
-        {
+        if (event.getEntity() instanceof Player player) {
             if (!isAdmin(player)) return;
 
             Admin admin = getOnlineAdmin(player);
@@ -150,7 +148,7 @@ public class AdminManager implements Listener
 
             Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(AdminToolbox.getInstance(), () -> {
                 player.setHealth(20);
-            },  1L);
+            }, 1L);
         }
     }
 

--- a/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
@@ -151,7 +151,7 @@ public class AdminManager implements Listener
     }
 
     @EventHandler
-    void onAdminHurt(PlayerDeathEvent event)
+    void onAdminDeath(PlayerDeathEvent event)
     {
         // admins not in free roam can't be hurt
         Player player = event.getPlayer();

--- a/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
@@ -1,6 +1,5 @@
 package org.modernbeta.admintoolbox.admins;
 
-import org.modernbeta.admintoolbox.AdminToolbox;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -9,6 +8,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.modernbeta.admintoolbox.AdminToolbox;
 
 import java.util.HashMap;
 import java.util.List;
@@ -139,17 +139,15 @@ public class AdminManager implements Listener
 
     @EventHandler
     void onAdminHurt(EntityDamageEvent event) {
-        // admins not in free roam can't be hurt
-        if (event.getEntity() instanceof Player player) {
-            if (!isAdmin(player)) return;
+        if (!(event.getEntity() instanceof Player player)) return;
+        if (!isAdmin(player)) return;
 
-            Admin admin = getOnlineAdmin(player);
-            if (admin.getAdminState() == AdminState.FREEROAM) return;
+        Admin admin = getOnlineAdmin(player);
+        if (admin.getAdminState() == AdminState.FREEROAM) return;
 
-            Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(AdminToolbox.getInstance(), () -> {
-                player.setHealth(20);
-            }, 1L);
-        }
+        Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(AdminToolbox.getInstance(), () -> {
+            player.setHealth(20);
+        }, 1L);
     }
 
     @EventHandler

--- a/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
@@ -147,9 +147,14 @@ public class AdminManager implements Listener
 
         double oldHealth = player.getHealth();
 
-        player.getScheduler().runDelayed(AdminToolbox.getInstance(), (task) -> {
-            player.setHealth(oldHealth);
-        }, null, 1L);
+        switch (event.getCause()) {
+            // don't cancel suffocation because some admins like to intentionally use this as a joke
+            case SUFFOCATION -> player.getScheduler().runDelayed(AdminToolbox.getInstance(), (task) -> {
+                player.setHealth(oldHealth);
+            }, null, 1L);
+            // otherwise we simply silently cancel other damage dealt to admins!
+            default -> event.setCancelled(true);
+        }
     }
 
     @EventHandler

--- a/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
@@ -1,16 +1,17 @@
 package org.modernbeta.admintoolbox.admins;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.modernbeta.admintoolbox.AdminToolbox;
 
 import java.util.HashMap;
 import java.util.List;
@@ -148,7 +149,7 @@ public class AdminManager implements Listener
         event.setCancelled(true);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST)
     void onAdminHurt(EntityDamageEvent event) {
         if (!(event.getEntity() instanceof Player player)) return;
         if (!isAdmin(player)) return;
@@ -156,17 +157,7 @@ public class AdminManager implements Listener
         Admin admin = getOnlineAdmin(player);
         if (admin.getAdminState() == AdminState.FREEROAM) return;
 
-        double oldHealth = player.getHealth();
-
-        switch (event.getCause()) {
-            // keep suffocation because if you /reveal inside a wall you're probably
-            // doing it on purpose to trigger suffocation damage :)
-            case SUFFOCATION ->
-                    player.getScheduler().runDelayed(AdminToolbox.getInstance(), (task) -> {
-                        player.setHealth(oldHealth);
-                    }, null, 1L);
-            default -> event.setCancelled(true);
-        }
+        event.setDamage(0.0);
     }
 
     @EventHandler

--- a/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
@@ -148,13 +148,12 @@ public class AdminManager implements Listener
         double oldHealth = player.getHealth();
 
         switch (event.getCause()) {
-            // we keep some damage types so admins don't appear to be cheating,
-            // and others because some staff use some as a joke sometimes :)
-            case FALL, SUFFOCATION, BLOCK_EXPLOSION, ENTITY_EXPLOSION, ENTITY_ATTACK, ENTITY_SWEEP_ATTACK ->
+            // keep suffocation because if you /reveal inside a wall you're probably
+            // doing it on purpose to trigger suffocation damage :)
+            case SUFFOCATION ->
                     player.getScheduler().runDelayed(AdminToolbox.getInstance(), (task) -> {
                         player.setHealth(oldHealth);
                     }, null, 1L);
-            // otherwise we silently cancel other damage dealt to admins!
             default -> event.setCancelled(true);
         }
     }

--- a/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
@@ -148,11 +148,13 @@ public class AdminManager implements Listener
         double oldHealth = player.getHealth();
 
         switch (event.getCause()) {
-            // don't cancel suffocation because some admins like to intentionally use this as a joke
-            case SUFFOCATION -> player.getScheduler().runDelayed(AdminToolbox.getInstance(), (task) -> {
-                player.setHealth(oldHealth);
-            }, null, 1L);
-            // otherwise we simply silently cancel other damage dealt to admins!
+            // we keep some damage types so admins don't appear to be cheating,
+            // and others because some staff use some as a joke sometimes :)
+            case FALL, SUFFOCATION, BLOCK_EXPLOSION, ENTITY_EXPLOSION, ENTITY_ATTACK, ENTITY_SWEEP_ATTACK ->
+                    player.getScheduler().runDelayed(AdminToolbox.getInstance(), (task) -> {
+                        player.setHealth(oldHealth);
+                    }, null, 1L);
+            // otherwise we silently cancel other damage dealt to admins!
             default -> event.setCancelled(true);
         }
     }


### PR DESCRIPTION
## Changes

- Reformatted onAdminHurt(EntityDamageEvent)
- Renamed onAdminHurt(PlayerDeathEvent) to onAdminDeath
- Updated logical flow to use a guard clause for `instanceof Player` check
- Save and restore admin's original health instead of setting health to max.
    * This could be exploited to cheat by using `/spectate` followed by `/reveal`, then intentionally taking fall damage to reset health when low.
- Cancel most damage types except those which should be clearly visible to other players

### Visible damage types

- Fall
- Suffocation (primarily used by some staff as a joke or to get players' attention during confrontation)
- Explosions (creepers and TNT)
- Attack damage (players and mobs)

## Demos


https://github.com/user-attachments/assets/47a0fce1-e1f1-42ed-91d0-3b49080b8c71

https://github.com/user-attachments/assets/7f5138ab-20a0-40dc-b047-4f81d51e0ce3

https://github.com/user-attachments/assets/0d991aee-1261-4e82-ae96-e3fbdf0ce80b
