### PR TITLE
Disable mob targeting of revealed admins 

### DIFF
--- a/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
@@ -1,14 +1,15 @@
 package org.modernbeta.admintoolbox.admins;
 
-import org.modernbeta.admintoolbox.AdminToolbox;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.modernbeta.admintoolbox.AdminToolbox;
 
 import java.util.HashMap;
 import java.util.List;
@@ -136,6 +137,14 @@ public class AdminManager implements Listener
                 event.setCancelled(true);
         }
     }*/
+
+    @EventHandler
+    void onEntityTargetAdmin(EntityTargetEvent event) {
+        if (!(event.getTarget() instanceof Player player)) return;
+        if (!isAdmin(player)) return;
+        if (getOnlineAdmin(player).adminState == AdminState.FREEROAM) return;
+        event.setCancelled(true);
+    }
 
     @EventHandler
     void onAdminHurt(EntityDamageEvent event)

--- a/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/admins/AdminManager.java
@@ -1,6 +1,7 @@
 package org.modernbeta.admintoolbox.admins;
 
 import org.bukkit.Bukkit;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -140,6 +141,7 @@ public class AdminManager implements Listener
 
     @EventHandler
     void onEntityTargetAdmin(EntityTargetEvent event) {
+        if (!(event.getEntity() instanceof LivingEntity)) return;
         if (!(event.getTarget() instanceof Player player)) return;
         if (!isAdmin(player)) return;
         if (getOnlineAdmin(player).adminState == AdminState.FREEROAM) return;


### PR DESCRIPTION
Ensures that no accidental creeper holes, ghast fireballs, or other unintentional world damage is ever caused by a revealed admin


https://github.com/user-attachments/assets/8fab3860-f2fa-455f-b10a-a1264fa5c780

