### PR TITLE
Hide players on BlueMap when in admin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,10 +14,14 @@ repositories {
 	maven("https://oss.sonatype.org/content/groups/public/") {
 		name = "sonatype"
 	}
+    maven("https://repo.bluecolored.de/releases") {
+        name = "bluemap"
+    }
 }
 
 dependencies {
 	compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
+    compileOnly("de.bluecolored:bluemap-api:2.7.4")
 }
 
 java {

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolbox.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolbox.java
@@ -8,7 +8,6 @@ import org.modernbeta.admintoolbox.commands.*;
 import org.modernbeta.admintoolbox.tools.Freeze;
 
 import javax.annotation.Nullable;
-import java.util.Optional;
 
 public final class AdminToolbox extends JavaPlugin implements Listener {
 
@@ -16,13 +15,17 @@ public final class AdminToolbox extends JavaPlugin implements Listener {
     AdminManager adminManager = new AdminManager();
 
     Freeze freeze = new Freeze();
-    public Optional<BlueMapAPI> blueMap;
+    @Nullable
+    public BlueMapAPI blueMap = null;
 
     @Override
     public void onEnable() {
         instance = this;
 
-        blueMap = BlueMapAPI.getInstance();
+        BlueMapAPI.onEnable(mapAPI -> {
+            getLogger().fine("BlueMap API is enabled, storing its instance");
+            this.blueMap = mapAPI;
+        });
 
         getServer().getPluginManager().registerEvents(adminManager, this);
         getServer().getPluginManager().registerEvents(freeze, this);

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolbox.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolbox.java
@@ -1,10 +1,10 @@
 package org.modernbeta.admintoolbox;
 
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.modernbeta.admintoolbox.admins.AdminManager;
 import org.modernbeta.admintoolbox.commands.*;
 import org.modernbeta.admintoolbox.tools.Freeze;
-import org.bukkit.event.Listener;
-import org.bukkit.plugin.java.JavaPlugin;
 
 public final class AdminToolbox extends JavaPlugin implements Listener {
 
@@ -14,18 +14,17 @@ public final class AdminToolbox extends JavaPlugin implements Listener {
     Freeze freeze = new Freeze();
 
     @Override
-    public void onEnable()
-    {
+    public void onEnable() {
         instance = this;
         getServer().getPluginManager().registerEvents(adminManager, this);
         getServer().getPluginManager().registerEvents(freeze, this);
-        getInstance().getCommand("target").setExecutor(new TargetCommand());
-        getInstance().getCommand("reveal").setExecutor(new RevealCommand());
-        getInstance().getCommand("back").setExecutor(new BackCommand());
-        getInstance().getCommand("forward").setExecutor(new ForwardCommand());
-        getInstance().getCommand("freeze").setExecutor(new FreezeCommand());
-        getInstance().getCommand("release").setExecutor(new ReleaseCommand());
-        getInstance().getCommand("yell").setExecutor(new YellCommand());
+        getCommand("target").setExecutor(new TargetCommand());
+        getCommand("reveal").setExecutor(new RevealCommand());
+        getCommand("back").setExecutor(new BackCommand());
+        getCommand("forward").setExecutor(new ForwardCommand());
+        getCommand("freeze").setExecutor(new FreezeCommand());
+        getCommand("release").setExecutor(new ReleaseCommand());
+        getCommand("yell").setExecutor(new YellCommand());
     }
 
     @Override

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolbox.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolbox.java
@@ -8,6 +8,7 @@ import org.modernbeta.admintoolbox.commands.*;
 import org.modernbeta.admintoolbox.tools.Freeze;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 public final class AdminToolbox extends JavaPlugin implements Listener {
 
@@ -15,16 +16,13 @@ public final class AdminToolbox extends JavaPlugin implements Listener {
     AdminManager adminManager = new AdminManager();
 
     Freeze freeze = new Freeze();
-    @Nullable
-    BlueMapAPI blueMap = null;
+    public Optional<BlueMapAPI> blueMap;
 
     @Override
     public void onEnable() {
         instance = this;
 
-        BlueMapAPI.getInstance().ifPresent(blueMapAPI -> {
-            this.blueMap = blueMapAPI;
-        });
+        blueMap = BlueMapAPI.getInstance();
 
         getServer().getPluginManager().registerEvents(adminManager, this);
         getServer().getPluginManager().registerEvents(freeze, this);

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolbox.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolbox.java
@@ -1,10 +1,13 @@
 package org.modernbeta.admintoolbox;
 
+import de.bluecolored.bluemap.api.BlueMapAPI;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.modernbeta.admintoolbox.admins.AdminManager;
 import org.modernbeta.admintoolbox.commands.*;
 import org.modernbeta.admintoolbox.tools.Freeze;
+
+import javax.annotation.Nullable;
 
 public final class AdminToolbox extends JavaPlugin implements Listener {
 
@@ -12,12 +15,20 @@ public final class AdminToolbox extends JavaPlugin implements Listener {
     AdminManager adminManager = new AdminManager();
 
     Freeze freeze = new Freeze();
+    @Nullable
+    BlueMapAPI blueMap = null;
 
     @Override
     public void onEnable() {
         instance = this;
+
+        BlueMapAPI.getInstance().ifPresent(blueMapAPI -> {
+            this.blueMap = blueMapAPI;
+        });
+
         getServer().getPluginManager().registerEvents(adminManager, this);
         getServer().getPluginManager().registerEvents(freeze, this);
+
         getCommand("target").setExecutor(new TargetCommand());
         getCommand("reveal").setExecutor(new RevealCommand());
         getCommand("back").setExecutor(new BackCommand());
@@ -28,9 +39,9 @@ public final class AdminToolbox extends JavaPlugin implements Listener {
     }
 
     @Override
-    public void onDisable()
-    {
+    public void onDisable() {
         adminManager.clearAdmins();
+        this.blueMap = null;
     }
 
     public static AdminToolbox getInstance()

--- a/src/main/java/org/modernbeta/admintoolbox/admins/Admin.java
+++ b/src/main/java/org/modernbeta/admintoolbox/admins/Admin.java
@@ -209,8 +209,8 @@ public class Admin
         savedPriorInventory = null;
 
         plugin.blueMap.ifPresent(mapAPI -> {
-            this.savedMapVisibility.ifPresent(oldVisiblity -> {
-                mapAPI.getWebApp().setPlayerVisibility(adminPlayer.getUniqueId(), oldVisiblity);
+            this.savedMapVisibility.ifPresent(oldVisibility -> {
+                mapAPI.getWebApp().setPlayerVisibility(adminPlayer.getUniqueId(), oldVisibility);
             });
         });
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: '${version}'
 main: org.modernbeta.admintoolbox.AdminToolbox
 api-version: '1.20'
 folia-supported: true
+softdepend: [ BlueMap ]
 commands:
   target:
     description: Puts admin in spectating mode and optionally teleports to target player


### PR DESCRIPTION
Automatically hide players on the BlueMap when they use `/reveal` (since players are already automatically hidden when in spectator mode) and restore their previous visibility on return to freeroam