### PR TITLE
Add Folia test server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -285,3 +285,5 @@ Temporary Items
 
 /target/
 .idea/
+
+/run/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,7 @@ runPaper.folia.registerTask {
 	minecraftVersion("1.20.4")
 
 	downloadPlugins {
-		// makes testing much easier
-		modrinth("viaversion", "5.3.2")
+		modrinth("viaversion", "5.3.2") // makes testing much easier
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	id("java")
 	id("com.github.johnrengelman.shadow") version "8.1.1"
+	id("xyz.jpenilla.run-paper") version "2.3.1"
 }
 
 group = "org.modernbeta.admintoolbox"
@@ -22,6 +23,15 @@ dependencies {
 
 java {
 	toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+}
+
+runPaper.folia.registerTask {
+	minecraftVersion("1.20.4")
+
+	downloadPlugins {
+		// makes testing much easier
+		modrinth("viaversion", "5.3.2")
+	}
 }
 
 tasks.build {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ runPaper.folia.registerTask {
 
 	downloadPlugins {
 		modrinth("viaversion", "5.3.2") // makes testing much easier
+		modrinth("bluemap", "5.5-paper")
 	}
 }
 


### PR DESCRIPTION
Makes it incredibly easy to simply start a Folia server within your IDE

Includes ViaVersion (to make testing easier) and BlueMap (for upcoming integration in #12)

<img width="359" alt="Screenshot 2025-04-28 at 5 09 48 AM" src="https://github.com/user-attachments/assets/5329fc28-dca1-402d-8cb2-544dbdc99fd7" />
