### PR TITLE
Remove admin state from admin-state.yml after restoring

### DIFF
--- a/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminManager.java
@@ -114,6 +114,10 @@ public class AdminManager implements Listener {
 				player.getInventory().setContents(originalInventory);
 				adminStates.remove(uuid);
 
+				FileConfiguration adminStateFile = plugin.getAdminStateConfig();
+				adminStateFile.set(player.getUniqueId().toString(), null);
+				plugin.saveAdminStateConfig();
+
 				BlueMapAPI.getInstance().ifPresent((blueMap) -> {
 					adminState.getSavedMapVisibility().ifPresent((visibility) -> {
 						blueMap.getWebApp().setPlayerVisibility(player.getUniqueId(), visibility);


### PR DESCRIPTION
After restoring original player state/inventory, the admin state should also be removed from `admin-state.yml` to prevent duplicating items and reverting to stale state on next login.

### Testing Steps

1. Enter targeting mode by typing /admin
2. Leave targeting mode by typing /admin again
3. Leave the game
4. Rejoin

### Previous Result
The admin state from Step 1 was restored even though the player was not in admin mode when leaving, which results in duplicated items, incorrect gamemode, and incorrect location.

### New Result
The player returns to whatever state they were in when they left, without duplicated items, incorrect gamemode, or deleted items.