### PR TITLE
Fix admin state during failed teleport

### DIFF
--- a/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminManager.java
@@ -1,6 +1,8 @@
 package org.modernbeta.admintoolbox.managers.admin;
 
 import de.bluecolored.bluemap.api.BlueMapAPI;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
@@ -42,7 +44,13 @@ public class AdminManager implements Listener {
 	public void target(Player player, Location location, boolean appending) {
 		AdminState adminState = AdminState.forPlayer(player);
 
+		Component actionBarMessage = MiniMessage.miniMessage().deserialize("<gold>Teleporting...");
+		player.sendActionBar(actionBarMessage);
+
 		player.teleportAsync(location, PlayerTeleportEvent.TeleportCause.COMMAND).thenAccept((didTeleport) -> {
+			// clear the action bar since the teleport is no longer pending
+			player.sendActionBar(Component.empty());
+
 			if (!didTeleport) {
 				player.sendRichMessage("<red>Error: You were not teleported!");
 				return;

--- a/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminManager.java
@@ -52,7 +52,7 @@ public class AdminManager implements Listener {
 			player.sendActionBar(Component.empty());
 
 			if (!didTeleport) {
-				player.sendRichMessage("<red>Error: You were not teleported!");
+				player.sendRichMessage("<red>You weren't teleported! Paper doesn't tell us why. :-/");
 				return;
 			}
 

--- a/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminManager.java
@@ -40,15 +40,7 @@ public class AdminManager implements Listener {
 	Map<UUID, AdminState> adminStates = new HashMap<>();
 
 	public void target(Player player, Location location, boolean appending) {
-		if (!isActiveAdmin(player)) {
-			adminStates.put(player.getUniqueId(), AdminState.forPlayer(player));
-			player.getInventory().clear();
-		} else if (appending) {
-			TeleportHistory<Location> history = adminStates.get(player.getUniqueId()).getTeleportHistory();
-			if (history != null) {
-				history.add(player.getLocation().clone());
-			}
-		}
+		AdminState adminState = AdminState.forPlayer(player);
 
 		player.teleportAsync(location, PlayerTeleportEvent.TeleportCause.COMMAND).thenAccept((didTeleport) -> {
 			if (!didTeleport) {
@@ -57,7 +49,17 @@ public class AdminManager implements Listener {
 			}
 
 			player.setGameMode(GameMode.SPECTATOR);
-			adminStates.get(player.getUniqueId()).setStatus(SPECTATING);
+			adminState.setStatus(SPECTATING);
+
+			if (!isActiveAdmin(player)) {
+				adminStates.put(player.getUniqueId(), adminState);
+				player.getInventory().clear();
+			} else if (appending) {
+				TeleportHistory<Location> history = adminStates.get(player.getUniqueId()).getTeleportHistory();
+				if (history != null) {
+					history.add(player.getLocation().clone());
+				}
+			}
 		});
 	}
 


### PR DESCRIPTION
## Only commit admin state if teleport is successful

If the teleportation fails, we no longer create and save an admin state. This caused a bug where the player would be placed in admin mode when rejoining.

## Send "Teleporting..." in action bar during asynchronous teleportation

Makes the process feel more responsive by giving the player a heads-up while chunk loading/generation is happening behind the scenes before they are teleported. This message is cleared from the action bar immediately once a teleportAsync result is received, regardless of whether it succeeded or failed.

## Explicitly blame Paper for failed teleportation

When player teleportation fails, Paper just gives us a `false` value (in `didTeleport`) and offers no logs or other way to figure out why it failed. We make this explicit to the player for now as a pacifier for our 👶 Modern Beta staff.

We should take some time later to try and find a way to triangulate the cause behind the failure even though we receive nothing explicitly. Unfortunately we're pinned to a severely outdated Paper version so PRing an improvement into Paper/Paper API upstream doesn't really help here, but could be beneficial for future us.