### PR TITLE
Add Streamer Mode (MCS-217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,21 +75,32 @@ Frozen players:
 
 To unfreeze a player, use `/unfreeze <player>`
 
+### Streamer Mode
+
+`/streamermode <duration>`, `/pausealerts <duration>`
+
+Allows players to temporarily disable certain permissions (i.e. those that give them staff-only alerts), intended for
+screen sharing or live-streaming gameplay.
+
+**New in version 1.2.0.**
+
 ## Permissions
 
-| Permission                       | Command                       | Description                                                                                                                                         |
-|----------------------------------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `admintoolbox.target`            | `/admin`, `/target`           | Spectate at current location                                                                                                                        |
-| `admintoolbox.target.player`     | `/target <player>`            | Spectate at a player's location                                                                                                                     |
-| `admintoolbox.target.location`   | `/target <x> [y] <z> [world]` | Spectate at provided coordinates                                                                                                                    |
-| `admintoolbox.reveal`            | `/reveal`                     | Reveal while spectating in admin mode                                                                                                               |
-| `admintoolbox.yell`              | `/yell`                       | Show titles to other players                                                                                                                        |
-| `admintoolbox.freeze`            | `/freeze`                     | Freeze and unfreeze players                                                                                                                         |
-| `admintoolbox.spawn`             | `/spawn`                      | Spectate at current world spawn                                                                                                                     |
-| `admintoolbox.spawn.all`         | `/spawn [world]`              | Spectate at all world spawns                                                                                                                        |
-| `admintoolbox.broadcast.receive` |                               | Receive alerts about other admins' actions                                                                                                          |
-| `admintoolbox.broadcast.exempt`  |                               | Admin actions will not alert others who can receive them                                                                                            |
-| `admintoolbox.admin`             |                               | Access to core AdminToolbox features. (**Deprecated**: Only for backward compatibility. This permission will be removed in the next major version.) |
+| Permission                            | Command                       | Description                                                                                                                                         |
+|---------------------------------------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `admintoolbox.target`                 | `/admin`, `/target`           | Spectate at current location                                                                                                                        |
+| `admintoolbox.target.player`          | `/target <player>`            | Spectate at a player's location                                                                                                                     |
+| `admintoolbox.target.location`        | `/target <x> [y] <z> [world]` | Spectate at provided coordinates                                                                                                                    |
+| `admintoolbox.reveal`                 | `/reveal`                     | Reveal while spectating in admin mode                                                                                                               |
+| `admintoolbox.yell`                   | `/yell`                       | Show titles to other players                                                                                                                        |
+| `admintoolbox.freeze`                 | `/freeze`                     | Freeze and unfreeze players                                                                                                                         |
+| `admintoolbox.spawn`                  | `/spawn`                      | Spectate at current world spawn                                                                                                                     |
+| `admintoolbox.spawn.all`              | `/spawn [world]`              | Spectate at all world spawns                                                                                                                        |
+| `admintoolbox.broadcast.receive`      |                               | Receive alerts about other admins' actions                                                                                                          |
+| `admintoolbox.broadcast.exempt`       |                               | Admin actions will not alert others who can receive them                                                                                            |
+| `admintoolbox.admin`                  |                               | Access to core AdminToolbox features. (**Deprecated**: Only for backward compatibility. This permission will be removed in the next major version.) |
+| `admintoolbox.streamermode`           | `/streamermode`               | Enter/exit Streamer Mode, revoking certain permissions.                                                                                             |
+| `admintoolbox.streamermode.unlimited` |                               | Bypass the maximum Streamer Mode duration set in config.yml.                                                                                        |
 
 ## Integrations
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ tasks.processResources {
 }
 
 val plugins = runPaper.downloadPluginsSpec {
-	modrinth("viaversion", "5.3.2") // makes testing much easier
+	modrinth("viaversion", "5.4.1") // makes testing much easier
 	modrinth("bluemap", "5.5-paper")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "org.modernbeta.admintoolbox"
-version = "1.1.2"
+version = "1.2.0"
 
 java {
 	toolchain.languageVersion.set(JavaLanguageVersion.of(21))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ repositories {
 
 dependencies {
 	compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
+	compileOnly("net.luckperms:api:5.4")
 	implementation("de.bluecolored:bluemap-api:2.7.4")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,7 @@ tasks.runServer {
 	downloadPlugins {
 		from(plugins)
 		// Add Folia-incompatible plugins below
+		modrinth("luckperms", "v5.5.0-bukkit") // they are working on Folia support but it's not ready yet!
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,14 +18,10 @@ repositories {
     maven("https://repo.bluecolored.de/releases") {
         name = "bluemap"
     }
-	maven("https://jitpack.io") {
-		name = "jitpack"
-	}
 }
 
 dependencies {
 	compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
-	implementation("com.github.LeonMangler:SuperVanish:6.2.18-3")
 	implementation("de.bluecolored:bluemap-api:2.7.4")
 }
 
@@ -52,8 +48,7 @@ tasks.runServer {
 	minecraftVersion("1.20.4")
 	downloadPlugins {
 		from(plugins)
-		// SuperVanish does not support Folia, so it only goes in the plain Paper server
-		github("LeonMangler", "SuperVanish", "6.2.18", "SuperVanish-6.2.18.jar")
+		// Add Folia-incompatible plugins below
 	}
 }
 

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
@@ -1,8 +1,11 @@
 package org.modernbeta.admintoolbox;
 
+import net.luckperms.api.LuckPerms;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.modernbeta.admintoolbox.commands.*;
 import org.modernbeta.admintoolbox.managers.FreezeManager;
@@ -23,6 +26,9 @@ public class AdminToolboxPlugin extends JavaPlugin {
 
 	PermissionAudience broadcastAudience;
 
+	@Nullable
+	private LuckPerms luckPermsAPI;
+
 	private File adminStateConfigFile;
 	private FileConfiguration adminStateConfig;
 
@@ -39,6 +45,11 @@ public class AdminToolboxPlugin extends JavaPlugin {
 		this.freezeManager = new FreezeManager();
 
 		this.broadcastAudience = new PermissionAudience(BROADCAST_AUDIENCE_PERMISSION);
+
+		{
+			RegisteredServiceProvider<LuckPerms> provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
+			if (provider != null) this.luckPermsAPI = provider.getProvider();
+		}
 
 		createAdminStateConfig();
 		this.adminStateConfig = getAdminStateConfig();
@@ -110,6 +121,10 @@ public class AdminToolboxPlugin extends JavaPlugin {
 
 	public PermissionAudience getAdminAudience() {
 		return broadcastAudience;
+	}
+
+	public Optional<LuckPerms> getLuckPermsAPI() {
+		return Optional.ofNullable(this.luckPermsAPI);
 	}
 
 	private void initializeConfig() {

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
@@ -16,10 +16,10 @@ import java.util.Optional;
 
 @SuppressWarnings("UnstableApiUsage")
 public class AdminToolboxPlugin extends JavaPlugin {
-    static AdminToolboxPlugin instance;
+	static AdminToolboxPlugin instance;
 
 	AdminManager adminManager;
-    FreezeManager freezeManager;
+	FreezeManager freezeManager;
 
 	PermissionAudience broadcastAudience;
 
@@ -34,20 +34,20 @@ public class AdminToolboxPlugin extends JavaPlugin {
 	private static final String BROADCAST_AUDIENCE_PERMISSION = "admintoolbox.broadcast.receive";
 	public static final String BROADCAST_EXEMPT_PERMISSION = "admintoolbox.broadcast.exempt";
 
-    @Override
-    public void onEnable() {
-        instance = this;
+	@Override
+	public void onEnable() {
+		instance = this;
 
 		this.adminManager = new AdminManager();
-        this.freezeManager = new FreezeManager();
+		this.freezeManager = new FreezeManager();
 
 		this.broadcastAudience = new PermissionAudience(BROADCAST_AUDIENCE_PERMISSION);
 
 		createAdminStateConfig();
 		this.adminStateConfig = getAdminStateConfig();
 
-        getServer().getPluginManager().registerEvents(adminManager, this);
-        getServer().getPluginManager().registerEvents(freezeManager, this);
+		getServer().getPluginManager().registerEvents(adminManager, this);
+		getServer().getPluginManager().registerEvents(freezeManager, this);
 
 		getCommand("target").setExecutor(new TargetCommand());
 		getCommand("reveal").setExecutor(new RevealCommand());
@@ -59,17 +59,17 @@ public class AdminToolboxPlugin extends JavaPlugin {
 		getCommand("spawn").setExecutor(new SpawnCommand());
 		getCommand("streamermode").setExecutor(new StreamerModeCommand());
 
-        getLogger().info(String.format("Enabled %s", getPluginMeta().getDisplayName()));
-    }
+		getLogger().info(String.format("Enabled %s", getPluginMeta().getDisplayName()));
+	}
 
-    @Override
-    public void onDisable() {
-        getLogger().info(String.format("Disabled %s", getPluginMeta().getDisplayName()));
-    }
+	@Override
+	public void onDisable() {
+		getLogger().info(String.format("Disabled %s", getPluginMeta().getDisplayName()));
+	}
 
 	private void createAdminStateConfig() {
 		this.adminStateConfigFile = new File(getDataFolder(), ADMIN_STATE_CONFIG_FILENAME);
-		if(!this.adminStateConfigFile.exists()) {
+		if (!this.adminStateConfigFile.exists()) {
 			this.adminStateConfigFile.getParentFile().mkdirs();
 			saveResource(ADMIN_STATE_CONFIG_FILENAME, false);
 		}
@@ -112,7 +112,6 @@ public class AdminToolboxPlugin extends JavaPlugin {
 	public PermissionAudience getAdminAudience() {
 		return broadcastAudience;
 	}
-
 
 
 	public Optional<SuperVanish> getVanish() {

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
@@ -2,6 +2,7 @@ package org.modernbeta.admintoolbox;
 
 import de.myzelyam.api.vanish.VanishAPI;
 import de.myzelyam.supervanish.SuperVanish;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -12,6 +13,7 @@ import org.modernbeta.admintoolbox.managers.admin.AdminManager;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 @SuppressWarnings("UnstableApiUsage")
@@ -58,6 +60,8 @@ public class AdminToolboxPlugin extends JavaPlugin {
 		getCommand("yell").setExecutor(new YellCommand());
 		getCommand("spawn").setExecutor(new SpawnCommand());
 		getCommand("streamermode").setExecutor(new StreamerModeCommand());
+
+		initializeConfig();
 
 		getLogger().info(String.format("Enabled %s", getPluginMeta().getDisplayName()));
 	}
@@ -113,8 +117,30 @@ public class AdminToolboxPlugin extends JavaPlugin {
 		return broadcastAudience;
 	}
 
-
 	public Optional<SuperVanish> getVanish() {
 		return Optional.ofNullable(VanishAPI.getPlugin());
+	}
+
+	private void initializeConfig() {
+		FileConfiguration config = getConfig();
+		YamlConfiguration defaults = new YamlConfiguration();
+
+		{
+			ConfigurationSection streamerMode = defaults.createSection("streamer-mode");
+			streamerMode.set("allow", true);
+			streamerMode.set("max-duration", 2400);
+			// TODO: fill in default disabled permission(s) -- just admintoolbox.broadcast.receive?
+			streamerMode.set("disable-permissions", List.of());
+
+			// docs
+			streamerMode.setInlineComments("allow", List.of("Enable or disable usage of Streamer Mode. 'true' enables usage of Streamer Mode, while 'false' disables Streamer Mode entirely."));
+			streamerMode.setInlineComments("max-duration", List.of("The maximum duration a player can enable Streamer Mode for, in minutes."));
+			streamerMode.setInlineComments("disable-permissions", List.of("The list of permissions to disable for the given time period."));
+		}
+
+		config.setDefaults(defaults);
+		config.options().copyDefaults(true);
+
+		saveConfig();
 	}
 }

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
@@ -1,7 +1,5 @@
 package org.modernbeta.admintoolbox;
 
-import de.myzelyam.api.vanish.VanishAPI;
-import de.myzelyam.supervanish.SuperVanish;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -24,9 +22,6 @@ public class AdminToolboxPlugin extends JavaPlugin {
 	FreezeManager freezeManager;
 
 	PermissionAudience broadcastAudience;
-
-	@Nullable
-	SuperVanish superVanish;
 
 	private File adminStateConfigFile;
 	private FileConfiguration adminStateConfig;
@@ -115,10 +110,6 @@ public class AdminToolboxPlugin extends JavaPlugin {
 
 	public PermissionAudience getAdminAudience() {
 		return broadcastAudience;
-	}
-
-	public Optional<SuperVanish> getVanish() {
-		return Optional.ofNullable(VanishAPI.getPlugin());
 	}
 
 	private void initializeConfig() {

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
@@ -57,6 +57,7 @@ public class AdminToolboxPlugin extends JavaPlugin {
 		getCommand("unfreeze").setExecutor(new UnfreezeCommand());
 		getCommand("yell").setExecutor(new YellCommand());
 		getCommand("spawn").setExecutor(new SpawnCommand());
+		getCommand("streamermode").setExecutor(new StreamerModeCommand());
 
         getLogger().info(String.format("Enabled %s", getPluginMeta().getDisplayName()));
     }

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
@@ -2,6 +2,7 @@ package org.modernbeta.admintoolbox;
 
 import net.luckperms.api.LuckPerms;
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -128,9 +129,14 @@ public class AdminToolboxPlugin extends JavaPlugin {
 		return Optional.ofNullable(this.luckPermsAPI);
 	}
 
-	private void initializeConfig() {
-		FileConfiguration config = getConfig();
-		YamlConfiguration defaults = new YamlConfiguration();
+	@Override
+	public void reloadConfig() {
+		super.reloadConfig();
+		getConfig().setDefaults(getConfigDefaults());
+	}
+
+	public Configuration getConfigDefaults() {
+		Configuration defaults = new YamlConfiguration();
 
 		{
 			ConfigurationSection streamerMode = defaults.createSection("streamer-mode");
@@ -144,6 +150,13 @@ public class AdminToolboxPlugin extends JavaPlugin {
 			streamerMode.setInlineComments("max-duration", List.of("The maximum duration a player can enable Streamer Mode for, in minutes."));
 			streamerMode.setInlineComments("disable-permissions", List.of("The list of permissions to disable for the given time period."));
 		}
+
+		return defaults;
+	}
+
+	private void initializeConfig() {
+		FileConfiguration config = getConfig();
+		Configuration defaults = getConfigDefaults();
 
 		config.setDefaults(defaults);
 		config.options().copyDefaults(true);

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
@@ -141,7 +141,7 @@ public class AdminToolboxPlugin extends JavaPlugin {
 		{
 			ConfigurationSection streamerMode = defaults.createSection("streamer-mode");
 			streamerMode.set("allow", true);
-			streamerMode.set("max-duration", 2400);
+			streamerMode.set("max-duration", 2400d);
 			streamerMode.set("disable-permissions", List.of("admintoolbox.broadcast.receive"));
 
 			// docs

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
@@ -142,7 +142,6 @@ public class AdminToolboxPlugin extends JavaPlugin {
 			ConfigurationSection streamerMode = defaults.createSection("streamer-mode");
 			streamerMode.set("allow", true);
 			streamerMode.set("max-duration", 2400);
-			// TODO: fill in default disabled permission(s) -- just admintoolbox.broadcast.receive?
 			streamerMode.set("disable-permissions", List.of("admintoolbox.broadcast.receive"));
 
 			// docs

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
@@ -136,7 +136,7 @@ public class AdminToolboxPlugin extends JavaPlugin {
 			streamerMode.set("allow", true);
 			streamerMode.set("max-duration", 2400);
 			// TODO: fill in default disabled permission(s) -- just admintoolbox.broadcast.receive?
-			streamerMode.set("disable-permissions", List.of());
+			streamerMode.set("disable-permissions", List.of("admintoolbox.broadcast.receive"));
 
 			// docs
 			streamerMode.setInlineComments("allow", List.of("Enable or disable usage of Streamer Mode. 'true' enables usage of Streamer Mode, while 'false' disables Streamer Mode entirely."));

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
@@ -57,6 +57,7 @@ public class AdminToolboxPlugin extends JavaPlugin {
 		getServer().getPluginManager().registerEvents(adminManager, this);
 		getServer().getPluginManager().registerEvents(freezeManager, this);
 
+		getCommand("admintoolbox").setExecutor(new PluginManageCommand());
 		getCommand("target").setExecutor(new TargetCommand());
 		getCommand("reveal").setExecutor(new RevealCommand());
 		getCommand("back").setExecutor(new GoBackCommand());

--- a/src/main/java/org/modernbeta/admintoolbox/commands/PluginManageCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/PluginManageCommand.java
@@ -1,0 +1,72 @@
+package org.modernbeta.admintoolbox.commands;
+
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.modernbeta.admintoolbox.AdminToolboxPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PluginManageCommand implements CommandExecutor, TabCompleter {
+	private final AdminToolboxPlugin plugin = AdminToolboxPlugin.getInstance();
+
+	private static final String MANAGE_COMMAND_PERMISSION = "admintoolbox.manage";
+	private static final String RELOAD_CONFIG_PERMISSION = "admintoolbox.manage.reload";
+
+	@Override
+	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+		if (!sender.hasPermission(MANAGE_COMMAND_PERMISSION))
+			return false; // Bukkit should handle this for us, just a sanity-check
+
+		switch (args.length) {
+			case 0 -> {
+				//noinspection UnstableApiUsage
+				sender.sendRichMessage(
+					"<gold>Hello from AdminToolbox version <yellow><version></yellow>!",
+					Placeholder.unparsed("version", plugin.getPluginMeta().getVersion())
+				);
+			}
+			case 1 -> {
+				if (args[0].equalsIgnoreCase("reload")) {
+					if (!sender.hasPermission(RELOAD_CONFIG_PERMISSION)) {
+						sender.sendRichMessage("<red>You don't have permission to do that!");
+						return true;
+					}
+
+					plugin.reloadConfig();
+					plugin.saveConfig();
+					sender.sendRichMessage("<gold>AdminToolbox configuration has been reloaded.");
+				} else {
+					sender.sendRichMessage("<red>Unknown action '<action>'!",
+						Placeholder.unparsed("action", args[0].toLowerCase()));
+				}
+			}
+		}
+
+		return true;
+	}
+
+	@Override
+	public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+		switch (args.length) {
+			case 1 -> {
+				String partialInput = args[0].toLowerCase();
+				List<String> supportedActions = new ArrayList<>();
+
+				if (sender.hasPermission(RELOAD_CONFIG_PERMISSION)) supportedActions.add("reload");
+
+				return supportedActions.stream()
+					.filter((action) -> action.startsWith(partialInput))
+					.toList();
+			}
+			default -> {
+				return List.of();
+			}
+		}
+	}
+}

--- a/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
@@ -28,7 +28,7 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 	private final AdminToolboxPlugin plugin = AdminToolboxPlugin.getInstance();
 
 	private static final String STREAMER_MODE_COMMAND_PERMISSION = "admintoolbox.streamermode";
-	private static final String STREAMER_MODE_META_KEY = "admintoolbox-streamermode";
+	private static final String STREAMER_MODE_META_KEY = "at-streamer-mode-enabled";
 
 	@Override
 	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {

--- a/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
@@ -39,6 +39,11 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 			return true;
 		}
 
+		if (!plugin.getConfig().getBoolean("streamer-mode.allow", false)) {
+			sender.sendRichMessage("<red>Streamer Mode is disabled on this server.<addendum>",
+				Placeholder.unparsed("addendum", player.isOp() ? " (streamer-mode -> allow is 'false' in config.yml)" : ""));
+			return true;
+		}
 		if (plugin.getLuckPermsAPI().isEmpty()) {
 			sender.sendRichMessage("<red>LuckPerms is required to use Streamer Mode. Is it enabled?");
 			return true;

--- a/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
@@ -1,5 +1,9 @@
 package org.modernbeta.admintoolbox.commands;
 
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.node.NodeType;
+import net.luckperms.api.node.types.MetaNode;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -10,31 +14,65 @@ import org.jetbrains.annotations.Nullable;
 import org.modernbeta.admintoolbox.AdminToolboxPlugin;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 	private final AdminToolboxPlugin plugin = AdminToolboxPlugin.getInstance();
 
 	private static final String STREAMER_MODE_COMMAND_PERMISSION = "admintoolbox.streamermode";
+	private static final String STREAMER_MODE_META_KEY = "admintoolbox-streamermode";
 
 	@Override
 	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
 		if (!sender.hasPermission(STREAMER_MODE_COMMAND_PERMISSION))
 			return false; // Bukkit should handle this for us, just a sanity-check
 		if (!(sender instanceof Player player)) {
-			sender.sendRichMessage("<red>Error: You must be a player to use this command.");
-			return false;
+			sender.sendRichMessage("<red>Only players may use Streamer Mode.");
+			return true;
 		}
 
-		// - toggle Streamer Mode
-		// - if enabling, parse provided duration
-		// - use LuckPerms API to add negated/'false' versions of permissions from config.yml to user for duration
-		// - if possible, use meta tag with expiry as well to denote streamer mode presence so we don't have to track it ourselves
+		if (plugin.getLuckPermsAPI().isEmpty()) {
+			sender.sendRichMessage("<red>LuckPerms is required to use Streamer Mode. Is it enabled?");
+			return true;
+		}
+		LuckPerms luckPerms = plugin.getLuckPermsAPI().get();
+
+		boolean isStreamerModeActive = luckPerms.getPlayerAdapter(Player.class)
+			.getMetaData(player)
+			.getMetaValue(STREAMER_MODE_META_KEY, Boolean::valueOf)
+			.orElse(false);
+
+		if (isStreamerModeActive) {
+			if (args.length > 0) return false;
+
+			// TODO: disable Streamer Mode
+			return true;
+		}
+
+		if(args.length != 1) return false;
+
+		// TODO: parse duration arg
+
+		User user = luckPerms.getPlayerAdapter(Player.class).getUser(player);
+		MetaNode metaNode = MetaNode.builder()
+			.key(STREAMER_MODE_META_KEY)
+			.value(Boolean.toString(true))
+			.expiry(1, TimeUnit.HOURS) // TODO: use parsed duration here
+			.build();
+
+		user.data().clear(NodeType.META.predicate((node) -> node.getMetaKey().equals(STREAMER_MODE_META_KEY)));
+		user.data().add(metaNode);
+
+		// TODO: use LuckPerms API to add negated/'false' versions of permissions from config.yml to user for duration
 
 		return true;
 	}
 
 	@Override
 	public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+		// if first arg is int-parseable, suggest time suffixes m/h (for minutes/hours)
+		// if player is in Streamer Mode, do not validate/suggest duration
+
 		return List.of();
 	}
 }

--- a/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
@@ -37,12 +37,7 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 		}
 		LuckPerms luckPerms = plugin.getLuckPermsAPI().get();
 
-		boolean isStreamerModeActive = luckPerms.getPlayerAdapter(Player.class)
-			.getMetaData(player)
-			.getMetaValue(STREAMER_MODE_META_KEY, Boolean::valueOf)
-			.orElse(false);
-
-		if (isStreamerModeActive) {
+		if (isStreamerModeActive(luckPerms, player)) {
 			if (args.length > 0) return false;
 
 			// TODO: disable Streamer Mode
@@ -74,5 +69,12 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 		// if player is in Streamer Mode, do not validate/suggest duration
 
 		return List.of();
+	}
+
+	private boolean isStreamerModeActive(LuckPerms luckPerms, Player player) {
+		return luckPerms.getPlayerAdapter(Player.class)
+			.getMetaData(player)
+			.getMetaValue(STREAMER_MODE_META_KEY, Boolean::valueOf)
+			.orElse(false);
 	}
 }

--- a/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
@@ -112,7 +112,7 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 		luckPerms.getUserManager().saveUser(user);
 
 		sender.sendRichMessage("<gold>Streamer Mode will be enabled for <yellow><duration></yellow>.",
-			Placeholder.unparsed("duration", duration.toString())); // TODO: do nice duration formatting!
+			Placeholder.unparsed("duration", formatDuration(duration)));
 		return true;
 	}
 
@@ -177,6 +177,18 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 		}
 
 		return Optional.of(Duration.of(durationNumber, unit));
+	}
+
+	private String formatDuration(Duration duration) {
+		int hours = duration.toHoursPart();
+		int minutes = duration.toMinutesPart();
+
+		List<String> resultList = new ArrayList<>();
+
+		if (hours > 0) resultList.add(hours + " hours");
+		if (minutes > 0) resultList.add(minutes + " minutes");
+
+		return String.join(" ", resultList);
 	}
 
 	private boolean isStreamerModeActive(LuckPerms luckPerms, Player player) {

--- a/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
@@ -1,9 +1,12 @@
 package org.modernbeta.admintoolbox.commands;
 
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.model.user.User;
+import net.luckperms.api.node.Node;
 import net.luckperms.api.node.NodeType;
 import net.luckperms.api.node.types.MetaNode;
+import net.luckperms.api.node.types.PermissionNode;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -18,7 +21,6 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -52,13 +54,21 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 
 		if(args.length != 1) return false;
 
-		// TODO: parse duration arg
+		Optional<Duration> parsedDuration = parseDuration(args[0]);
+
+		if (parsedDuration.isEmpty()) {
+			sender.sendRichMessage("<red>'<yellow><input></yellow>' is not a supported duration!",
+				Placeholder.unparsed("input", args[0]));
+			return true;
+		}
+
+		Duration duration = parsedDuration.get();
 
 		User user = luckPerms.getPlayerAdapter(Player.class).getUser(player);
 		MetaNode metaNode = MetaNode.builder()
 			.key(STREAMER_MODE_META_KEY)
 			.value(Boolean.toString(true))
-			.expiry(1, TimeUnit.HOURS) // TODO: use parsed duration here
+			.expiry(duration)
 			.build();
 
 		user.data().clear(NodeType.META.predicate((node) -> node.getMetaKey().equals(STREAMER_MODE_META_KEY)));

--- a/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
@@ -1,0 +1,40 @@
+package org.modernbeta.admintoolbox.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.modernbeta.admintoolbox.AdminToolboxPlugin;
+
+import java.util.List;
+
+public class StreamerModeCommand implements CommandExecutor, TabCompleter {
+	private final AdminToolboxPlugin plugin = AdminToolboxPlugin.getInstance();
+
+	private static final String STREAMER_MODE_COMMAND_PERMISSION = "admintoolbox.streamermode";
+
+	@Override
+	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+		if (!sender.hasPermission(STREAMER_MODE_COMMAND_PERMISSION))
+			return false; // Bukkit should handle this for us, just a sanity-check
+		if (!(sender instanceof Player player)) {
+			sender.sendRichMessage("<red>Error: You must be a player to use this command.");
+			return false;
+		}
+
+		// - toggle Streamer Mode
+		// - if enabling, parse provided duration
+		// - use LuckPerms API to add negated/'false' versions of permissions from config.yml to user for duration
+		// - if possible, use meta tag with expiry as well to denote streamer mode presence so we don't have to track it ourselves
+
+		return true;
+	}
+
+	@Override
+	public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+		return List.of();
+	}
+}

--- a/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
@@ -74,7 +74,17 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 		user.data().clear(NodeType.META.predicate((node) -> node.getMetaKey().equals(STREAMER_MODE_META_KEY)));
 		user.data().add(metaNode);
 
-		// TODO: use LuckPerms API to add negated/'false' versions of permissions from config.yml to user for duration
+		// using LuckPerms API, add negated/'false' versions of permissions from config.yml to user for duration
+		List<String> disablePermissions = plugin.getConfig().getStringList("streamer-mode.disable-permissions");
+		for (String permission : disablePermissions) {
+			Node permissionNode = PermissionNode.builder()
+				.permission(permission)
+				.expiry(duration)
+				.negated(true)
+				.build();
+
+			user.data().add(permissionNode);
+		}
 
 		return true;
 	}

--- a/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
@@ -57,6 +57,7 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 					&& node.getExpiryDuration() != null
 					&& disablePermissions.contains(node.getPermission())
 			));
+			luckPerms.getUserManager().saveUser(user);
 
 			sender.sendRichMessage("<gold>Streamer Mode has been disabled.");
 			return true;
@@ -93,6 +94,8 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 
 			user.data().add(permissionNode);
 		}
+
+		luckPerms.getUserManager().saveUser(user);
 
 		return true;
 	}

--- a/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
@@ -71,10 +71,30 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 
 	@Override
 	public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-		// if first arg is int-parseable, suggest time suffixes m/h (for minutes/hours)
-		// if player is in Streamer Mode, do not validate/suggest duration
+		if (args.length != 1) return List.of();
+		if (plugin.getLuckPermsAPI().isEmpty()) return List.of();
+		if (!(sender instanceof Player player)) return List.of();
 
-		return List.of();
+		// if player is in Streamer Mode, do not validate/suggest duration since this is an 'off' toggle!
+		{
+			LuckPerms luckPerms = plugin.getLuckPermsAPI().get();
+			if (isStreamerModeActive(luckPerms, player)) return List.of();
+		}
+
+		String partialArgument = args[0];
+
+		// if arg is int-parseable, suggest time suffixes m/h (for minutes/hours)
+		try {
+			Integer.parseUnsignedInt(partialArgument);
+		} catch (NumberFormatException e) {
+			return List.of();
+		}
+
+		List<String> supportedUnits = List.of("h", "m");
+
+		return supportedUnits.stream()
+			.map((unit) -> partialArgument + unit) // suggests typed number with units at end - i.e. 15 -> 15m, 15h
+			.toList();
 	}
 
 	/// Rudimentary regex-based parser for durations.

--- a/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
@@ -19,6 +19,7 @@ import org.modernbeta.admintoolbox.AdminToolboxPlugin;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -28,6 +29,7 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 	private final AdminToolboxPlugin plugin = AdminToolboxPlugin.getInstance();
 
 	private static final String STREAMER_MODE_COMMAND_PERMISSION = "admintoolbox.streamermode";
+	private static final String STREAMER_MODE_BYPASS_MAX_DURATION_PERMISSION = "admintoolbox.streamermode.unlimited";
 	private static final String STREAMER_MODE_META_KEY = "at-streamer-mode-enabled";
 
 	@Override
@@ -79,6 +81,13 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 		}
 
 		Duration duration = parsedDuration.get();
+
+		final double maxDurationMinutes = plugin.getConfig().getDouble("streamer-mode.max-duration");
+		if (duration.getSeconds() > (maxDurationMinutes * 60)
+			&& !sender.hasPermission(STREAMER_MODE_BYPASS_MAX_DURATION_PERMISSION)) {
+			sender.sendRichMessage("<red>That duration is above the maximum allowed!");
+			return true;
+		}
 
 		MetaNode metaNode = MetaNode.builder()
 			.key(STREAMER_MODE_META_KEY)

--- a/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/StreamerModeCommand.java
@@ -97,6 +97,8 @@ public class StreamerModeCommand implements CommandExecutor, TabCompleter {
 
 		luckPerms.getUserManager().saveUser(user);
 
+		sender.sendRichMessage("<gold>Streamer Mode will be enabled for <yellow><duration></yellow>.",
+			Placeholder.unparsed("duration", duration.toString())); // TODO: do nice duration formatting!
 		return true;
 	}
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,7 @@ api-version: '1.20'
 folia-supported: true
 softdepend: [ BlueMap, LuckPerms ]
 
+default-permission: op
 permissions:
   admintoolbox.target:
     description: Can spectate at current location.
@@ -45,7 +46,6 @@ permissions:
       - admintoolbox.broadcast.receive
   admintoolbox.streamermode:
     description: Can enter and exit Streamer Mode.
-default-permission: op
 
 commands:
   spectate:
@@ -93,5 +93,5 @@ commands:
   streamermode:
     description: Enter Streamer Mode, temporarily disabling certain privileges.
     usage: /<command> [duration]
-    aliases: [ sm, hidealerts, ha, alertsoff, pausealerts, pa ]
+    aliases: [ sm, pausealerts, pa ]
     permission: admintoolbox.streamermode

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -43,6 +43,8 @@ permissions:
       - admintoolbox.freeze
       - admintoolbox.yell
       - admintoolbox.broadcast.receive
+  admintoolbox.streamermode:
+    description: Can enter and exit Streamer Mode.
 default-permission: op
 
 commands:
@@ -88,3 +90,8 @@ commands:
     usage: /<command> [world]
     aliases: [ targetspawn ]
     permission: admintoolbox.spawn
+  streamermode:
+    description: Enter Streamer Mode, temporarily disabling certain privileges.
+    usage: /<command> [duration]
+    aliases: [ sm, hidealerts, ha, alertsoff, pausealerts, pa ]
+    permission: admintoolbox.streamermode

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ authors: [ Karltroid, iLynxcat ]
 main: org.modernbeta.admintoolbox.AdminToolboxPlugin
 api-version: '1.20'
 folia-supported: true
-softdepend: [ BlueMap ]
+softdepend: [ BlueMap, LuckPerms ]
 
 permissions:
   admintoolbox.target:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,6 +8,12 @@ softdepend: [ BlueMap, LuckPerms ]
 
 default-permission: op
 permissions:
+  admintoolbox.manage:
+    description: Can use the AdminToolbox management command.
+    default: true
+  admintoolbox.manage.reload:
+    description: Can reload AdminToolbox's configuration.
+    children: [ admintoolbox.manage ]
   admintoolbox.target:
     description: Can spectate at current location.
   admintoolbox.target.player:
@@ -48,6 +54,11 @@ permissions:
     description: Can enter and exit Streamer Mode.
 
 commands:
+  admintoolbox:
+    description: Manage the AdminToolbox plugin.
+    usage: /<command> <reload>
+    permission: admintoolbox.manage
+    aliases: [ atb ]
   spectate:
     description: Spectate in admin mode, optionally at a provided location.
     usage: |

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -51,6 +51,8 @@ permissions:
       - admintoolbox.broadcast.receive
   admintoolbox.streamermode:
     description: Can enter and exit Streamer Mode.
+  admintoolbox.streamermode.unlimited:
+    description: Can bypass maximum duration in Streamer Mode.
 
 commands:
   admintoolbox:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ authors: [ Karltroid, iLynxcat ]
 main: org.modernbeta.admintoolbox.AdminToolboxPlugin
 api-version: '1.20'
 folia-supported: true
-softdepend: [ BlueMap, SuperVanish, PremiumVanish ]
+softdepend: [ BlueMap ]
 
 permissions:
   admintoolbox.target:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,7 +10,6 @@ default-permission: op
 permissions:
   admintoolbox.manage:
     description: Can use the AdminToolbox management command.
-    default: true
   admintoolbox.manage.reload:
     description: Can reload AdminToolbox's configuration.
     children: [ admintoolbox.manage ]


### PR DESCRIPTION
This PR introduces Streamer Mode (**/streamermode**) to AdminToolbox, allowing permitted players to disable a given set of permissions for a provided time period they choose. The idea is that these permissions include certain moderation permissions, specifically those that would alert the player in chat (i.e. anti-cheat alerts, admin broadcasts, even *all* moderation permissions — determined at the server admins' discretion).

Because this feature set required adding a config.yml to the plugin, a new command (**/admintoolbox**) was added to allow hot-reloading of the config file.

## To-do

- [ ] Test Folia compatibility (hard to do with vanilla LuckPerms, but there is a branch of LP we can test with)
- [ ] Polish Streamer Mode time parsing and formatting in feedback (steal from TT /age?)
