### PR TITLE
add bStats to AdminToolbox

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
 	compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
+	compileOnly("org.bstats:bstats-bukkit:3.0.2")
 	implementation("com.github.LeonMangler:SuperVanish:6.2.18-3")
 	implementation("de.bluecolored:bluemap-api:2.7.4")
 }

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
@@ -2,6 +2,7 @@ package org.modernbeta.admintoolbox;
 
 import de.myzelyam.api.vanish.VanishAPI;
 import de.myzelyam.supervanish.SuperVanish;
+import org.bstats.bukkit.Metrics;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -28,6 +29,8 @@ public class AdminToolboxPlugin extends JavaPlugin {
 
 	private File adminStateConfigFile;
 	private FileConfiguration adminStateConfig;
+
+	private static final int BSTATS_PLUGIN_ID = 26406; // bStats: ModernBeta/AdminToolbox
 
 	private static final String ADMIN_STATE_CONFIG_FILENAME = "admin-state.yml";
 
@@ -57,6 +60,12 @@ public class AdminToolboxPlugin extends JavaPlugin {
 		getCommand("unfreeze").setExecutor(new UnfreezeCommand());
 		getCommand("yell").setExecutor(new YellCommand());
 		getCommand("spawn").setExecutor(new SpawnCommand());
+
+		{
+			Metrics metrics = new Metrics(this, BSTATS_PLUGIN_ID);
+
+			// add custom chart stats here if desired
+		}
 
         getLogger().info(String.format("Enabled %s", getPluginMeta().getDisplayName()));
     }


### PR DESCRIPTION
this PR adds a simple bStats implementation to AdminToolbox

would love to explore bringing in a property from gradle.properties or similar to set BSTATS_PLUGIN_ID instead of hard-coding it