### PR TITLE
Add report system: players can submit location-based reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ original location, placed back into survival mode, and their original inventory 
 - `/spawn` - Enter admin mode at the current world's spawn point
 - `/spawn <world>` - Enter admin mode at the provided world's spawn point
 
+
+### Report System
+
+- `/report <reason>` — Players send a report with their current location and a timestamp. Admins receive a broadcast where the coordinates are clickable to spectate in admin mode.
+- `/reports [page]` — View open reports (5 per page). Each entry shows player, coords, and world. Hovering shows the reason, time, and the report ID. The coords are clickable to spectate in admin mode, and an inline `[Resolve]` button lets admins resolve the report.
+- `/reports resolve <id>` — Resolve by ID (or click the inline `[Resolve]` button).
+
+Notes:
+- Cooldown: players must wait 5 minutes between `/report` submissions.
+- Permission: `admintoolbox.reports` is required to view/resolve reports.
+
 #### Navigation
 
 - `/back` - Move to previous location in teleport history
@@ -91,6 +102,7 @@ screen sharing or live-streaming gameplay.
 | `admintoolbox.reveal`                 | `/reveal`                     | Reveal while spectating in admin mode                                                                                                               |
 | `admintoolbox.yell`                   | `/yell`                       | Show titles to other players                                                                                                                        |
 | `admintoolbox.freeze`                 | `/freeze`                     | Freeze and unfreeze players                                                                                                                         |
+| `admintoolbox.reports`                | `/reports`                    | View and manage player reports                                                                                                                      |
 | `admintoolbox.spawn`                  | `/spawn`                      | Spectate at current world spawn                                                                                                                     |
 | `admintoolbox.spawn.all`              | `/spawn [world]`              | Spectate at all world spawns                                                                                                                        |
 | `admintoolbox.broadcast.receive`      |                               | Receive alerts about other admins' actions                                                                                                          |

--- a/src/main/java/org/modernbeta/admintoolbox/commands/ReportCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/ReportCommand.java
@@ -1,0 +1,118 @@
+package org.modernbeta.admintoolbox.commands;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.modernbeta.admintoolbox.AdminToolboxPlugin;
+import org.modernbeta.admintoolbox.models.Report;
+import org.modernbeta.admintoolbox.utils.LocationUtils;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ReportCommand implements CommandExecutor, TabCompleter {
+	private final AdminToolboxPlugin plugin = AdminToolboxPlugin.getInstance();
+	private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+	private static final long COOLDOWN_MINUTES = 5;
+	private final Map<UUID, LocalDateTime> cooldowns = new HashMap<>();
+
+	private static final List<String> REPORT_SUGGESTIONS = List.of(
+		"griefing",
+		"stealing",
+		"bug"
+	);
+
+	@Override
+	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+		if (!(sender instanceof Player player)) {
+			sender.sendRichMessage("<red>You must be a player to use this command.");
+			return true;
+		}
+
+		if (args.length == 0) {
+			player.sendRichMessage("<red>Please provide a reason for your report. Usage: /report <reason>");
+			return true;
+		}
+
+		LocalDateTime lastReport = cooldowns.get(player.getUniqueId());
+		if (lastReport != null) {
+			Duration timeSince = Duration.between(lastReport, LocalDateTime.now());
+			if (timeSince.toMinutes() < COOLDOWN_MINUTES) {
+				long remainingSeconds = COOLDOWN_MINUTES * 60 - timeSince.getSeconds();
+				long minutes = remainingSeconds / 60;
+				long seconds = remainingSeconds % 60;
+				player.sendRichMessage("<red>You must wait <time> before sending another report.",
+					Placeholder.unparsed("time", String.format("%d:%02d", minutes, seconds)));
+				return true;
+			}
+		}
+
+		Location loc = player.getLocation();
+		String reason = String.join(" ", args);
+
+		Report report = plugin.getReportManager().createReport(
+			player.getUniqueId(),
+			player.getName(),
+			loc,
+			reason
+		);
+
+		String coords = String.format("%.1f, %.1f, %.1f", loc.getX(), loc.getY(), loc.getZ());
+		String timestamp = report.getTimestamp().format(TIME_FORMATTER);
+
+		String worldNameForCommand = LocationUtils.getShortWorldName(loc.getWorld());
+		String targetCommand = String.format("/target %d %d %d %s",
+				loc.getBlockX(), loc.getBlockY(), loc.getBlockZ(), worldNameForCommand);
+
+		Component coordsComponent = Component.text(coords)
+			.clickEvent(ClickEvent.runCommand(targetCommand))
+			.hoverEvent(HoverEvent.showText(Component.text("Click to spectate here")));
+
+		plugin.getAdminAudience()
+			.sendMessage(MiniMessage.miniMessage().deserialize(
+				"<gold>[Report] <player> at <gray><coords></gray> in <world> (<timestamp>):<gray> <reason>",
+				Placeholder.component("player", player.name()),
+				Placeholder.component("coords", coordsComponent),
+				Placeholder.unparsed("world", loc.getWorld() != null ? loc.getWorld().getName() : worldNameForCommand),
+				Placeholder.unparsed("timestamp", timestamp),
+				Placeholder.unparsed("reason", reason)
+			));
+
+		player.sendRichMessage("<green>Your report has been submitted. Thank you!");
+		cooldowns.put(player.getUniqueId(), LocalDateTime.now());
+
+		return true;
+	}
+
+	@Override
+	public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+		if (args.length == 0) {
+			return REPORT_SUGGESTIONS;
+		}
+
+		String currentArg = args[args.length - 1].toLowerCase();
+
+		List<String> filtered = REPORT_SUGGESTIONS.stream()
+			.filter(suggestion -> suggestion.toLowerCase().startsWith(currentArg))
+			.collect(Collectors.toList());
+
+		if (args.length == 1) {
+			return filtered;
+		}
+
+		return filtered.isEmpty() ? List.of() : filtered;
+	}
+}

--- a/src/main/java/org/modernbeta/admintoolbox/commands/ReportsCommand.java
+++ b/src/main/java/org/modernbeta/admintoolbox/commands/ReportsCommand.java
@@ -1,0 +1,196 @@
+package org.modernbeta.admintoolbox.commands;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.modernbeta.admintoolbox.AdminToolboxPlugin;
+import org.modernbeta.admintoolbox.models.Report;
+import org.modernbeta.admintoolbox.utils.LocationUtils;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ReportsCommand implements CommandExecutor, TabCompleter {
+    private final AdminToolboxPlugin plugin = AdminToolboxPlugin.getInstance();
+    private static final String REPORTS_COMMAND_PERMISSION = "admintoolbox.reports";
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final int REPORTS_PER_PAGE = 5;
+    private static final int PAGE_BASE = 1;
+
+	@Override
+	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command,
+							 @NotNull String label, @NotNull String[] args) {
+		if (!sender.hasPermission(REPORTS_COMMAND_PERMISSION))
+			return false;
+
+		if (args.length >= 2 && args[0].equalsIgnoreCase("resolve")) {
+			handleResolve(sender, args[1]);
+			return true;
+		}
+
+        int page = PAGE_BASE;
+        if (args.length >= 1) {
+            try {
+                page = Integer.parseInt(args[0]);
+            } catch (NumberFormatException e) {
+                sender.sendRichMessage("<red>Invalid page number.");
+                return true;
+            }
+        }
+
+		showReports(sender, page);
+		return true;
+	}
+
+	private void showReports(CommandSender sender, int page) {
+		List<Report> openReports = plugin.getReportManager().getOpenReports();
+
+		if (openReports.isEmpty()) {
+			sender.sendRichMessage("<green>No open reports.");
+			return;
+		}
+
+        int totalPages = (int) Math.ceil((double) openReports.size() / REPORTS_PER_PAGE);
+        page = Math.max(PAGE_BASE, Math.min(page, totalPages));
+
+        int startIndex = (page - PAGE_BASE) * REPORTS_PER_PAGE;
+        int endIndex = Math.min(startIndex + REPORTS_PER_PAGE, openReports.size());
+
+		sender.sendMessage(Component.text("═══ Open Reports (Page " + page + "/" + totalPages + ") ═══", NamedTextColor.GOLD));
+
+		for (int i = startIndex; i < endIndex; i++) {
+			Report report = openReports.get(i);
+			Location loc = report.getLocation();
+			String coords = String.format("%.1f, %.1f, %.1f", loc.getX(), loc.getY(), loc.getZ());
+			String timestamp = report.getTimestamp().format(TIME_FORMATTER);
+
+			Component reportLine;
+
+			Component hoverText = MiniMessage.miniMessage().deserialize(
+				"<gold>Reason:</gold> <reason>\n<gold>Time:</gold> <timestamp>\n<green>Click to spectate\n<dark_gray>ID: <id>",
+				Placeholder.unparsed("reason", report.getReason()),
+				Placeholder.unparsed("timestamp", timestamp),
+				Placeholder.unparsed("id", report.getId().toString())
+			);
+
+			int bx = loc.getBlockX();
+			int by = loc.getBlockY();
+			int bz = loc.getBlockZ();
+			String worldNameForCommand = LocationUtils.getShortWorldName(loc.getWorld());
+			String targetCommand = String.format("/target %d %d %d %s", bx, by, bz, worldNameForCommand);
+
+			Component coordsComponent = Component.text(coords)
+				.clickEvent(ClickEvent.runCommand(targetCommand))
+				.hoverEvent(HoverEvent.showText(hoverText));
+
+			Component inlineResolve = Component.text("[Resolve]", NamedTextColor.GREEN)
+				.clickEvent(ClickEvent.runCommand("/reports resolve " + report.getId()))
+				.hoverEvent(HoverEvent.showText(Component.text("Click to resolve this report")));
+
+			reportLine = MiniMessage.miniMessage().deserialize(
+				"<gray>[<id>]</gray> <gold><player></gold> at <coords> in <world> <resolve>",
+                Placeholder.unparsed("id", String.valueOf(i + PAGE_BASE)),
+				Placeholder.unparsed("player", report.getPlayerName()),
+				Placeholder.component("coords", coordsComponent),
+				Placeholder.component("resolve", inlineResolve),
+				Placeholder.unparsed("world", loc.getWorld() != null ? loc.getWorld().getName() : worldNameForCommand)
+			);
+
+			reportLine = reportLine.hoverEvent(HoverEvent.showText(hoverText));
+
+			sender.sendMessage(reportLine);
+
+			sender.sendMessage(Component.text("  " + report.getReason(), NamedTextColor.GRAY));
+		}
+
+        if (totalPages > PAGE_BASE) {
+            Component nav = createNavigationComponent(page, totalPages);
+            sender.sendMessage(nav);
+        }
+    }
+
+	private static @NotNull Component createNavigationComponent(int page, int totalPages) {
+		Component nav = Component.text("");
+        if (page > PAGE_BASE) {
+            nav = nav.append(Component.text("[Previous]", NamedTextColor.YELLOW)
+                .clickEvent(ClickEvent.runCommand("/reports " + (page - PAGE_BASE)))
+                .hoverEvent(HoverEvent.showText(Component.text("Go to page " + (page - PAGE_BASE)))));
+        }
+        if (page < totalPages) {
+            if (page > PAGE_BASE) nav = nav.append(Component.text(" "));
+            nav = nav.append(Component.text("[Next]", NamedTextColor.YELLOW)
+                .clickEvent(ClickEvent.runCommand("/reports " + (page + PAGE_BASE)))
+                .hoverEvent(HoverEvent.showText(Component.text("Go to page " + (page + PAGE_BASE)))));
+        }
+		return nav;
+	}
+
+	private void handleResolve(CommandSender sender, String reportIdStr) {
+		UUID reportId;
+		try {
+			reportId = UUID.fromString(reportIdStr);
+		} catch (IllegalArgumentException e) {
+			sender.sendRichMessage("<red>Invalid report ID.");
+			return;
+		}
+
+		Optional<Report> reportOpt = plugin.getReportManager().getReport(reportId);
+		if (reportOpt.isEmpty()) {
+			sender.sendRichMessage("<red>Report not found.");
+			return;
+		}
+
+		Report report = reportOpt.get();
+		if (report.isResolved()) {
+			sender.sendRichMessage("<red>Report is already resolved.");
+			return;
+		}
+
+		UUID resolvedBy = sender instanceof Player ? ((Player) sender).getUniqueId() : null;
+		plugin.getReportManager().resolveReport(reportId, resolvedBy);
+
+		sender.sendRichMessage("<green>Report resolved.");
+
+		plugin.getAdminAudience()
+			.excluding(sender)
+			.sendMessage(MiniMessage.miniMessage().deserialize(
+				"<gray><admin> resolved a report from <player>.",
+				Placeholder.component("admin", sender.name()),
+				Placeholder.unparsed("player", report.getPlayerName())
+			));
+	}
+
+	@Override
+	public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command,
+												@NotNull String label, @NotNull String[] args) {
+		if (args.length == 1) {
+			return Stream.of("resolve")
+				.filter(s -> s.startsWith(args[0].toLowerCase()))
+				.collect(Collectors.toList());
+		}
+
+		if (args.length == 2 && args[0].equalsIgnoreCase("resolve")) {
+			return plugin.getReportManager().getOpenReports().stream()
+				.map(report -> report.getId().toString())
+				.filter(id -> id.startsWith(args[1].toLowerCase()))
+				.collect(Collectors.toList());
+		}
+
+		return List.of();
+	}
+}

--- a/src/main/java/org/modernbeta/admintoolbox/managers/ReportManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/managers/ReportManager.java
@@ -1,0 +1,137 @@
+package org.modernbeta.admintoolbox.managers;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.modernbeta.admintoolbox.AdminToolboxPlugin;
+import org.modernbeta.admintoolbox.models.Report;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ReportManager {
+	private final AdminToolboxPlugin plugin = AdminToolboxPlugin.getInstance();
+	private final Map<UUID, Report> reports = new HashMap<>();
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+	public ReportManager() {
+		loadReports();
+	}
+
+	public Report createReport(UUID playerUUID, String playerName, Location location, String reason) {
+		Report report = new Report(playerUUID, playerName, location, reason);
+		reports.put(report.getId(), report);
+		saveReports();
+		return report;
+	}
+
+	public List<Report> getOpenReports() {
+		return reports.values().stream()
+			.filter(report -> !report.isResolved())
+			.sorted(Comparator.comparing(Report::getTimestamp))
+			.collect(Collectors.toList());
+	}
+
+	public List<Report> getAllReports() {
+		return new ArrayList<>(reports.values());
+	}
+
+	public Optional<Report> getReport(UUID id) {
+		return Optional.ofNullable(reports.get(id));
+	}
+
+	public void resolveReport(UUID reportId, UUID resolvedBy) {
+		Report report = reports.get(reportId);
+		if (report != null) {
+			report.resolve(resolvedBy);
+			saveReports();
+		}
+	}
+
+	private void loadReports() {
+		FileConfiguration config = plugin.getReportsConfig();
+		ConfigurationSection reportsSection = config.getConfigurationSection("reports");
+
+		if (reportsSection == null) {
+			return;
+		}
+
+		for (String key : reportsSection.getKeys(false)) {
+			ConfigurationSection reportSection = reportsSection.getConfigurationSection(key);
+			if (reportSection == null) continue;
+
+			try {
+				UUID id = UUID.fromString(key);
+				UUID playerUUID = UUID.fromString(Objects.requireNonNull(reportSection.getString("playerUUID")));
+				String playerName = reportSection.getString("playerName");
+				Location location = deserializeLocation(reportSection.getConfigurationSection("location"));
+				LocalDateTime timestamp = LocalDateTime.parse(Objects.requireNonNull(reportSection.getString("timestamp")), FORMATTER);
+				String reason = reportSection.getString("reason");
+				boolean resolved = reportSection.getBoolean("resolved", false);
+				UUID resolvedBy = reportSection.getString("resolvedBy") != null
+					? UUID.fromString(Objects.requireNonNull(reportSection.getString("resolvedBy")))
+					: null;
+				LocalDateTime resolvedAt = reportSection.getString("resolvedAt") != null
+					? LocalDateTime.parse(Objects.requireNonNull(reportSection.getString("resolvedAt")), FORMATTER)
+					: null;
+
+				Report report = new Report(id, playerUUID, playerName, location, timestamp, reason, resolved, resolvedBy, resolvedAt);
+				reports.put(id, report);
+			} catch (Exception e) {
+				plugin.getLogger().warning("Failed to load report: " + key);
+			}
+		}
+	}
+
+	private void saveReports() {
+		FileConfiguration config = plugin.getReportsConfig();
+		config.set("reports", null);
+
+		ConfigurationSection reportsSection = config.createSection("reports");
+
+		for (Report report : reports.values()) {
+			ConfigurationSection reportSection = reportsSection.createSection(report.getId().toString());
+			reportSection.set("playerUUID", report.getPlayerUUID().toString());
+			reportSection.set("playerName", report.getPlayerName());
+			reportSection.set("location", serializeLocation(report.getLocation()));
+			reportSection.set("timestamp", report.getTimestamp().format(FORMATTER));
+			reportSection.set("reason", report.getReason());
+			reportSection.set("resolved", report.isResolved());
+			if (report.getResolvedBy() != null) {
+				reportSection.set("resolvedBy", report.getResolvedBy().toString());
+			}
+			if (report.getResolvedAt() != null) {
+				reportSection.set("resolvedAt", report.getResolvedAt().format(FORMATTER));
+			}
+		}
+
+		plugin.saveReportsConfig();
+	}
+
+    private Map<String, Object> serializeLocation(Location loc) {
+        Map<String, Object> map = new HashMap<>();
+        String worldName = (loc.getWorld() != null)
+            ? loc.getWorld().getName()
+            : Bukkit.getWorlds().getFirst().getName();
+        map.put("world", worldName);
+        map.put("x", loc.getX());
+        map.put("y", loc.getY());
+        map.put("z", loc.getZ());
+        return map;
+    }
+
+	private Location deserializeLocation(ConfigurationSection section) {
+		if (section == null) return null;
+
+		String worldName = section.getString("world");
+		double x = section.getDouble("x");
+		double y = section.getDouble("y");
+		double z = section.getDouble("z");
+
+		assert worldName != null;
+		return new Location(Bukkit.getWorld(worldName), x, y, z);
+	}
+}

--- a/src/main/java/org/modernbeta/admintoolbox/models/Report.java
+++ b/src/main/java/org/modernbeta/admintoolbox/models/Report.java
@@ -1,0 +1,82 @@
+package org.modernbeta.admintoolbox.models;
+
+import org.bukkit.Location;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class Report {
+	private final UUID id;
+	private final UUID playerUUID;
+	private final String playerName;
+	private final Location location;
+	private final LocalDateTime timestamp;
+	private final String reason;
+	private boolean resolved;
+	private UUID resolvedBy;
+	private LocalDateTime resolvedAt;
+
+	public Report(UUID playerUUID, String playerName, Location location, String reason) {
+		this.id = UUID.randomUUID();
+		this.playerUUID = playerUUID;
+		this.playerName = playerName;
+		this.location = location;
+		this.timestamp = LocalDateTime.now();
+		this.reason = reason;
+		this.resolved = false;
+	}
+
+	public Report(UUID id, UUID playerUUID, String playerName, Location location, LocalDateTime timestamp, String reason, boolean resolved, UUID resolvedBy, LocalDateTime resolvedAt) {
+		this.id = id;
+		this.playerUUID = playerUUID;
+		this.playerName = playerName;
+		this.location = location;
+		this.timestamp = timestamp;
+		this.reason = reason;
+		this.resolved = resolved;
+		this.resolvedBy = resolvedBy;
+		this.resolvedAt = resolvedAt;
+	}
+
+	public UUID getId() {
+		return id;
+	}
+
+	public UUID getPlayerUUID() {
+		return playerUUID;
+	}
+
+	public String getPlayerName() {
+		return playerName;
+	}
+
+	public Location getLocation() {
+		return location;
+	}
+
+	public LocalDateTime getTimestamp() {
+		return timestamp;
+	}
+
+	public String getReason() {
+		return reason;
+	}
+
+	public boolean isResolved() {
+		return resolved;
+	}
+
+	public void resolve(UUID resolvedBy) {
+		this.resolved = true;
+		this.resolvedBy = resolvedBy;
+		this.resolvedAt = LocalDateTime.now();
+	}
+
+	public UUID getResolvedBy() {
+		return resolvedBy;
+	}
+
+	public LocalDateTime getResolvedAt() {
+		return resolvedAt;
+	}
+}

--- a/src/main/java/org/modernbeta/admintoolbox/utils/LocationUtils.java
+++ b/src/main/java/org/modernbeta/admintoolbox/utils/LocationUtils.java
@@ -55,14 +55,19 @@ public class LocationUtils {
 			.filter((name) -> name.toLowerCase().startsWith(partialNameLower));
 	}
 
-	public static String getShortWorldName(World world) {
-		World defaultWorld = Bukkit.getWorlds().getFirst();
+    public static String getShortWorldName(World world) {
+        World defaultWorld = Bukkit.getWorlds().getFirst();
 
-		if (world.getName().equals(defaultWorld.getName())) return world.getName();
+        if (world == null) {
+            // Fallback: return default world name to avoid NPEs
+            return defaultWorld.getName();
+        }
 
-		// get name without `world_` (+1 accounts for the underscore)
-		return world.getName().substring(defaultWorld.getName().length() + 1);
-	}
+        if (world.getName().equals(defaultWorld.getName())) return world.getName();
+
+        // get name without `world_` (+1 accounts for the underscore)
+        return world.getName().substring(defaultWorld.getName().length() + 1);
+    }
 
 	public static String prettifyCoordinates(Location location) {
 		return String.format(

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -37,6 +37,8 @@ permissions:
   admintoolbox.broadcast.exempt:
     description: Admin actions will not alert others who can receive them.
     default: false
+  admintoolbox.reports:
+    description: Can view and manage player reports.
   # Legacy catch-all admin permission. Children list is designed to be
   # backwards-compatible with pre-1.0.0 versions of AdminToolbox.
   admintoolbox.admin:
@@ -49,6 +51,7 @@ permissions:
       - admintoolbox.freeze
       - admintoolbox.yell
       - admintoolbox.broadcast.receive
+      - admintoolbox.reports
   admintoolbox.streamermode:
     description: Can enter and exit Streamer Mode.
   admintoolbox.streamermode.unlimited:
@@ -108,3 +111,10 @@ commands:
     usage: /<command> [duration]
     aliases: [ sm, pausealerts, pa ]
     permission: admintoolbox.streamermode
+  report:
+    description: Send a report to online admins with your location and timestamp.
+    usage: /<command> [reason]
+  reports:
+    description: View and manage open reports.
+    usage: /<command> [page|resolve <id>]
+    permission: admintoolbox.reports

--- a/src/main/resources/reports.yml
+++ b/src/main/resources/reports.yml
@@ -1,0 +1,5 @@
+# This file stores player reports for AdminToolbox
+# Do not edit manually unless you know what you're doing.
+
+reports: {}
+


### PR DESCRIPTION
Integrates a reporting system allowing players to submit reports with reasons, timestamps, and current location. Admins can view open reports, spectate the reported locations, and resolve issues directly via commands or UI. Includes cooldown, permissions, and persistence layer.