### PR TITLE
stats: remove config toggle in favor of bStats global toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ use when screen sharing or live-streaming gameplay.
 **Added in version 1.4.0.**
 
 For us to better understand how many servers are using AdminToolbox, by default we collect anonymized analytics via
-bStats. Server administrators can disable this functionality by setting `enable-stats: false` in config.yml.
+bStats. Server administrators can disable this functionality on their servers by setting `enabled: false` in
+`plugins/bStats/config.yml`.
 
 The anonymized collected data is viewable publicly at https://bstats.org/plugin/bukkit/AdminToolbox/26406.
 

--- a/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
+++ b/src/main/java/org/modernbeta/admintoolbox/AdminToolboxPlugin.java
@@ -94,11 +94,8 @@ public class AdminToolboxPlugin extends JavaPlugin {
 			getLogger().warning("BlueMap API not found! Some features will be unavailable.");
 		}
 
-		if (getConfig().getBoolean("enable-stats")) {
-			getLogger().info("Enabling bStats for plugin statistics.");
-			// bStats - plugin analytics
-			new Metrics(this, BSTATS_PLUGIN_ID);
-		}
+		// bStats - plugin analytics. Toggleable in server-level bStats config.
+		new Metrics(this, BSTATS_PLUGIN_ID);
 
 		getLogger().info(String.format("Enabled %s", getPluginMeta().getDisplayName()));
 	}
@@ -173,9 +170,6 @@ public class AdminToolboxPlugin extends JavaPlugin {
 	public Configuration getConfigDefaults() {
 		Configuration defaults = new YamlConfiguration();
 
-		defaults.set("enable-stats", true);
-		defaults.setComments("enable-stats", List.of("'false' entirely disables sending statistics via bStats."));
-
 		{
 			ConfigurationSection streamerMode = defaults.createSection("streamer-mode");
 			streamerMode.set("allow", true);
@@ -197,6 +191,11 @@ public class AdminToolboxPlugin extends JavaPlugin {
 
 		config.setDefaults(defaults);
 		config.options().copyDefaults(true);
+
+		// Remove `enable-stats` option, it's toggleable at the server level.
+		if (config.isSet("enable-stats")) {
+			getConfig().set("enable-stats", null);
+		}
 
 		saveConfig();
 		reloadConfig();


### PR DESCRIPTION
We don't need a toggle in our config for this, as this is configurable at the server level by default.

This PR:
- Automatically removes the `enable-stats` config key if present in config.yml
- Always instantiates Metrics when plugin loads, which will respect the server-level toggle
- Updates Analytics section in readme to reflect this