### PR TITLE
feat: send broadcasts when players use spectator menu

### DIFF
--- a/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminManager.java
@@ -277,6 +277,10 @@ public class AdminManager implements Listener {
 	/**
 	 * Prevent players in admin mode from using the spectator teleport menu unless they have
 	 * permission to teleport to players directly.
+	 *
+	 * <p>
+	 * <strong>PlayerTeleportEvent does not fire on Folia servers.</strong>
+	 * See <a href="https://github.com/PaperMC/Folia/issues/105#issuecomment-1610418720">PaperMC/Folia#105</a>
 	 */
 	@EventHandler
 	void onAdminTeleport(PlayerTeleportEvent teleportEvent) {


### PR DESCRIPTION
## Known issues

On Folia, PlayerTeleportEvent does not fire (at all) so our permission check does not work to prevent players from using it. We also can't use it to broadcast when an admin spectates a player. No known workaround.