### PR TITLE
fix: Session restore list index overflow when using a plugin that modifies the slot count

### DIFF
--- a/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminManager.java
+++ b/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminManager.java
@@ -27,6 +27,7 @@ import org.modernbeta.admintoolbox.AdminToolboxPlugin;
 import org.modernbeta.admintoolbox.managers.admin.AdminState.TeleportHistory;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -178,14 +179,14 @@ public class AdminManager implements Listener {
 		return Optional.ofNullable(adminStates.get(player.getUniqueId()));
 	}
 
-	private @Nullable AdminState loadStateFromFile(UUID playerId) {
+	private @Nullable AdminState loadStateFromFile(Player player) {
 		FileConfiguration state = plugin.getAdminStateConfig();
-		if (!state.isConfigurationSection(playerId.toString())) return null;
+		if (!state.isConfigurationSection(player.getUniqueId().toString())) return null;
 
-		ConfigurationSection playerSection = state.getConfigurationSection(playerId.toString());
+		ConfigurationSection playerSection = state.getConfigurationSection(player.getUniqueId().toString());
 		assert playerSection != null;
 
-		return AdminState.fromConfig(playerId, playerSection);
+		return AdminState.fromConfig(player, playerSection);
 	}
 
 	private CompletableFuture<Location> getNextLowestSafeLocation(Location location) {
@@ -253,7 +254,7 @@ public class AdminManager implements Listener {
 	@EventHandler(priority = EventPriority.HIGHEST)
 	void onAdminJoin(PlayerJoinEvent joinEvent) {
 		Player player = joinEvent.getPlayer();
-		Optional.ofNullable(loadStateFromFile(player.getUniqueId()))
+		Optional.ofNullable(loadStateFromFile(player))
 			.ifPresent((state) -> {
 				adminStates.put(player.getUniqueId(), state);
 

--- a/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminState.java
+++ b/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminState.java
@@ -65,12 +65,11 @@ public class AdminState {
 	}
 
 	static AdminState fromConfig(UUID playerId, ConfigurationSection playerSection) {
-		final int PLAYER_INVENTORY_SLOTS = 41;
-
-		ItemStack[] items = new ItemStack[PLAYER_INVENTORY_SLOTS];
+		ItemStack[] items = new ItemStack[0];
 		if (playerSection.contains("inventory")) {
 			List<?> invList = playerSection.getList("inventory");
 			if (invList != null) {
+				items = new ItemStack[invList.size()];
 				for (int i = 0; i < invList.size(); i++) {
 					Object obj = invList.get(i);
 					if (obj == null) {

--- a/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminState.java
+++ b/src/main/java/org/modernbeta/admintoolbox/managers/admin/AdminState.java
@@ -64,13 +64,18 @@ public class AdminState {
 		);
 	}
 
-	static AdminState fromConfig(UUID playerId, ConfigurationSection playerSection) {
+	static AdminState fromConfig(Player player, ConfigurationSection playerSection) {
+		UUID playerId = player.getUniqueId();
+
 		ItemStack[] items = new ItemStack[0];
 		if (playerSection.contains("inventory")) {
 			List<?> invList = playerSection.getList("inventory");
 			if (invList != null) {
-				items = new ItemStack[invList.size()];
-				for (int i = 0; i < invList.size(); i++) {
+				// NOTE: This is a hotfix for users who use plugins that change the inventory size
+				// from the vanilla default of 41. We used to hardcode this, it caused an
+				// exception when restoring.
+				items = new ItemStack[Math.min(invList.size(), player.getInventory().getContents().length)];
+				for (int i = 0; i < items.length; i++) {
 					Object obj = invList.get(i);
 					if (obj == null) {
 						items[i] = null; // preserve empty slots


### PR DESCRIPTION
Fixes #51 

## Problem

- Plugins like InvSee++ may modify the amount of slots in a player's inventory
- We hardcode the slot count at the vanilla limit of 41
- This causes an overflow when saving -> restoring sessions to/from `admin-state.yml`

## Solution

- Pass the full <code>Player</code> reference down to <code>AdminState#fromConfig</code>
- Use the lower value of these two for the array's size
    - Number of items in saved list
    - Total slots in Player's inventory
- This should now gracefully handle mismatches

### To-do
- Test with [InvSee++](https://modrinth.com/plugin/invsee++) installed
    - [x] ~~Verify bug on 1.5.1 release~~
        Not sure on an exact replication, can't seem to make it produce more than 41 items. Pushing this fix anyway for verification by the user
    - [ ] Verify fix at 7afc63d